### PR TITLE
Perf: remove <time-element>

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,6 @@
     "octicons": "*",
     "paper-elements": "Polymer/paper-elements#~0.5.1",
     "webcomponentjs": "Polymer/webcomponentsjs#~0.5.1",
-    "polymer": "Polymer/polymer#~0.5.1",
-    "time-elements": "~0.4.0"
+    "polymer": "Polymer/polymer#~0.5.1"
   }
 }

--- a/src/elements/cards/ticker-github-events-card.jade
+++ b/src/elements/cards/ticker-github-events-card.jade
@@ -5,11 +5,6 @@ link(rel='import' href='./ticker-github-branch.html')
 link(rel='import' href='./ticker-github-repo.html')
 link(rel='import' href='./ticker-github-avatar.html')
 
-//- TODO(pwong): Consider creating a slimmer <time-element>.
-//-              Ticker's use cases for display time are so limited, size and
-//-              speed could be improve with a slimmer purpose made time element.
-script(src='../../../bower_components/time-elements/time-elements.js')
-
 +polymer-element(attributes='events')
 
   template#Comment
@@ -17,12 +12,8 @@ script(src='../../../bower_components/time-elements/time-elements.js')
       marked-element(text='[[]]')
 
   template#EventTimeAgo
-    time(
-      class='c-gray-dark t-font-size-11'
-      datetime='[[created_at]]'
-      format='micro'
-      is='time-ago'
-    )
+    span(class='c-gray-dark t-font-size-11')
+      | [[created_at | timeAgo]]
 
   template#CardTitle
     .title

--- a/src/elements/cards/ticker-github-events-card.jade
+++ b/src/elements/cards/ticker-github-events-card.jade
@@ -11,14 +11,10 @@ link(rel='import' href='./ticker-github-avatar.html')
     .action__content(flex class='t-word-wrap-break-word')
       marked-element(text='[[]]')
 
-  template#EventTimeAgo
-    span(class='c-gray-dark t-font-size-11')
-      | [[created_at | timeAgo]]
-
   template#CardTitle
     .title
       ticker-github-repo(flex repo='[[repo.name]]')
-      template(ref='EventTimeAgo' bind='[[]]')
+      span(class='c-gray-dark t-font-size-11') [[created_at | timeAgo]]
 
 
   template#PullRequestEvent
@@ -157,7 +153,7 @@ link(rel='import' href='./ticker-github-avatar.html')
           icon='github:star'
         )
         ticker-github-repo(flex class='c-gray-darker t-truncate' repo='[[repo.name]]')
-        template(ref='EventTimeAgo' bind='[[]]')
+        span(class='c-gray-dark t-font-size-11') [[created_at | timeAgo]]
 
 
   template#ForkEvent
@@ -169,7 +165,7 @@ link(rel='import' href='./ticker-github-avatar.html')
           icon='github:repo-forked'
         )
         ticker-github-repo(flex class='c-gray-darker' repo='[[repo.name]]')
-        template(ref='EventTimeAgo' bind='[[]]')
+        span(class='c-gray-dark t-font-size-11') [[created_at | timeAgo]]
 
 
   template#PushEvent

--- a/src/elements/ticker-app.js
+++ b/src/elements/ticker-app.js
@@ -3,6 +3,7 @@ import appState from '../states/appState';
 
 // Load Global Filters
 import limitArray from '../filters/limitArray';
+import timeAgo from '../filters/timeAgo';
 
 StatefulPolymer('ticker-app', {
   state:appState,

--- a/src/filters/timeAgo.js
+++ b/src/filters/timeAgo.js
@@ -1,0 +1,16 @@
+const MIN_MS     = 1000 * 60;
+const HOUR_MS    = MIN_MS * 60;
+const DAY_MS     = HOUR_MS * 24;
+
+var timeAgoNow = Date.now();
+setTimeout(function(){timeAgoNow = Date.now()}, MIN_MS*5);
+
+export default function timeAgo(dateTime){
+  var diffms = timeAgoNow - dateTime;
+  return  diffms > DAY_MS  ? `${~~(diffms / DAY_MS)}d`
+        : diffms > HOUR_MS ? `${~~(diffms / HOUR_MS)}h`
+        : diffms > MIN_MS  ? `${~~(diffms / MIN_MS)}m`
+        : '1m';
+}
+
+PolymerExpressions.prototype.timeAgo = timeAgo;


### PR DESCRIPTION
Performance profile revealed alot of time spent in the `<time-element>`'s `ExtendedTimePrototype.getFormattedTitle()`...

![screen shot 2014-11-24 at 11 03 00 pm](https://cloud.githubusercontent.com/assets/284734/5178291/cf39bd9c-742e-11e4-92a6-174a3fc9f813.png)

Removing this element for a simpler `timeAgo` filter reduces rendering the relative time to a millisecond...

![screen shot 2014-11-24 at 11 16 49 pm](https://cloud.githubusercontent.com/assets/284734/5178394/1c051ada-7430-11e4-80f5-acf206d4d9e0.png)
